### PR TITLE
Fall back to "Plain Text" if embeds are missing

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -108,6 +108,9 @@ pub enum ContextReference {
     ByScope {
         scope: Scope,
         sub_context: Option<String>,
+        /// If this reference by scope is part of an `embed` for which there is an `escape`.
+        /// In other words a reference for a context for which there "always is a way out".
+        with_escape: bool,
     },
     File {
         name: String,

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -727,30 +727,39 @@ impl SyntaxSetBuilder {
                     all_context_ids[syntax_index].get(s)
                 }
             }
-            ByScope { scope, ref sub_context } => {
-                let context_name = sub_context.as_ref().map_or("main", |x| &**x);
-                syntaxes
-                    .iter()
-                    .enumerate()
-                    .rev()
-                    .find(|index_and_syntax| index_and_syntax.1.scope == scope)
-                    .and_then(|index_and_syntax| all_context_ids[index_and_syntax.0].get(context_name))
-            }
-            File { ref name, ref sub_context } => {
-                let context_name = sub_context.as_ref().map_or("main", |x| &**x);
-                syntaxes
-                    .iter()
-                    .enumerate()
-                    .rev()
-                    .find(|index_and_syntax| &index_and_syntax.1.name == name)
-                    .and_then(|index_and_syntax| all_context_ids[index_and_syntax.0].get(context_name))
-            }
+            ByScope {
+                scope,
+                ref sub_context,
+            } => Self::find_id(sub_context, all_context_ids, syntaxes, |index_and_syntax| {
+                index_and_syntax.1.scope == scope
+            }),
+            File {
+                ref name,
+                ref sub_context,
+            } => Self::find_id(sub_context, all_context_ids, syntaxes, |index_and_syntax| {
+                &index_and_syntax.1.name == name
+            }),
             Direct(_) => None,
         };
         if let Some(context_id) = linked_context_id {
             let mut new_ref = Direct(*context_id);
             mem::swap(context_ref, &mut new_ref);
         }
+    }
+
+    fn find_id<'a>(
+        sub_context: &Option<String>,
+        all_context_ids: &'a [HashMap<String, ContextId>],
+        syntaxes: &'a [SyntaxReference],
+        predicate: impl FnMut(&(usize, &SyntaxReference)) -> bool,
+    ) -> Option<&'a ContextId> {
+        let context_name = sub_context.as_ref().map_or("main", |x| &**x);
+        syntaxes
+            .iter()
+            .enumerate()
+            .rev()
+            .find(predicate)
+            .and_then(|index_and_syntax| all_context_ids[index_and_syntax.0].get(context_name))
     }
 
     fn link_match_pat(


### PR DESCRIPTION
Currently, syntect (and bat, see https://github.com/sharkdp/bat/issues/915) panics for syntaxes that tries to embed a scope (typically another language) that is not present.

However, in the same scenario, Sublime Text does not crash. Instead, Sublime seems to fallback to Plain Text syntax, which actually seems very reasonable. Because `embed`s always have an `escape` out of the Plain Text.

This PR implements falling back to Plain Text if embeds are missing.

I'm marking this as Draft because
 * There is one test case that is failing, but I think it can be fixed "safely"
 * This is based on #382 which is not merged yet

I would love to get your early feedback on this approach before I polish it further. Do you think this could work?