### PR TITLE
TEMP CI TEST: Make `highlight_line()` and `parse_line()` return `Result`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ let syntax = ps.find_syntax_by_extension("rs").unwrap();
 let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 for line in LinesWithEndings::from(s) {
-    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
     print!("{}", escaped);
 }

--- a/benches/highlight_utils/mod.rs
+++ b/benches/highlight_utils/mod.rs
@@ -7,7 +7,7 @@ pub fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, t
     let mut h = HighlightLines::new(syntax, theme);
     let mut count = 0;
     for line in s.lines() {
-        let regions = h.highlight_line(line, syntax_set);
+        let regions = h.highlight_line(line, syntax_set).unwrap();
         count += regions.len();
     }
     count

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -8,7 +8,7 @@ fn do_parse(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference) -> usize {
     let mut state = ParseState::new(syntax);
     let mut count = 0;
     for line in s.lines() {
-        let ops = state.parse_line(line, ss);
+        let ops = state.parse_line(line, ss).unwrap();
         count += ops.len();
     }
     count

--- a/examples/latex-demo.rs
+++ b/examples/latex-demo.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
     for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
         let escaped = as_latex_escaped(&ranges[..]);
         println!("\n{:?}", line);
         println!("\n{}", escaped);

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -45,7 +45,7 @@ fn main() {
             let mut highlighter = HighlightFile::new(filename, &syntax_set, theme).unwrap();
 
             for line in contents {
-                for region in highlighter.highlight_lines.highlight_line(line, &syntax_set) {
+                for region in highlighter.highlight_lines.highlight_line(line, &syntax_set).unwrap() {
                     regions.push(region);
                 }
             }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -103,7 +103,7 @@ fn main() {
                 }
 
                 {
-                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss);
+                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss).unwrap();
                     print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
                 }
                 line.clear();

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -46,7 +46,7 @@ fn main() {
     let sr_rs = ss.find_syntax_by_extension("rs").unwrap();
     let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_rs, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_rs) {
-        rs_html_generator.parse_html_for_line_which_includes_newline(line);
+        rs_html_generator.parse_html_for_line_which_includes_newline(line).unwrap();
     }
     let html_rs = rs_html_generator.finalize();
 
@@ -64,7 +64,7 @@ int main() {
     let sr_cpp = ss.find_syntax_by_extension("cpp").unwrap();
     let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_cpp, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_cpp) {
-        cpp_html_generator.parse_html_for_line_which_includes_newline(line);
+        cpp_html_generator.parse_html_for_line_which_includes_newline(line).unwrap();
     }
     let html_cpp = cpp_html_generator.finalize();
 

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -133,7 +133,7 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let mut stack = ScopeStack::new();
     while reader.read_line(&mut line).unwrap() > 0 {
         {
-            let ops = state.parse_line(&line, ss);
+            let ops = state.parse_line(&line, ss).unwrap();
             stats.chars += line.len();
             count_line(&ops, &line, &mut stack, stats);
         }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -273,7 +273,7 @@ fn test_file(
                     current_line_number, stack
                 );
             }
-            let ops = state.parse_line(&line, ss);
+            let ops = state.parse_line(&line, ss).unwrap();
             if out_opts.debug && !line_only_has_assertion {
                 if ops.is_empty() && !line.is_empty() {
                     println!("no operations for this line...");

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -389,7 +389,7 @@ mod tests {
 
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = "module Bob::Wow::Troll::Five; 5; end";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str)> = iter.collect();
         // println!("{:#?}", regions);
@@ -426,7 +426,7 @@ mod tests {
         // We start by parsing a python multiline-comment: """
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = r#"""""#;
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         assert_eq!(1, iter.count());
         let path = highlight_state.path;
@@ -434,7 +434,7 @@ mod tests {
         // We then parse the next line with a highlight state built from the previous state
         let mut highlight_state = HighlightState::new(&highlighter, path);
         let line = "multiline comment";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str)> = iter.collect();
 
@@ -548,7 +548,7 @@ mod tests {
 
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = "module Bob::Wow::Troll::Five; 5; end";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = RangedHighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str, Range<usize>)> = iter.collect();
         // println!("{:#?}", regions);

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -31,7 +31,7 @@ pub struct ThemeSettings {
     /// Color of the caret.
     pub caret: Option<Color>,
     /// Color of the line the caret is in.
-    /// Only used when the `higlight_line` setting is set to `true`.
+    /// Only used when the `highlight_line` setting is set to `true`.
     pub line_highlight: Option<Color>,
 
     /// The color to use for the squiggly underline drawn under misspelled words.

--- a/src/html.rs
+++ b/src/html.rs
@@ -87,8 +87,8 @@ impl<'a> ClassedHTMLGenerator<'a> {
     ///
     /// *Note:* This function requires `line` to include a newline at the end and
     /// also use of the `load_defaults_newlines` version of the syntaxes.
-    pub fn parse_html_for_line_which_includes_newline(&mut self, line: &str) {
-        let parsed_line = self.parse_state.parse_line(line, self.syntax_set);
+    pub fn parse_html_for_line_which_includes_newline(&mut self, line: &str) -> Result<(), Error>{
+        let parsed_line = self.parse_state.parse_line(line, self.syntax_set)?;
         let (formatted_line, delta) = line_tokens_to_classed_spans(
             line,
             parsed_line.as_slice(),
@@ -97,6 +97,8 @@ impl<'a> ClassedHTMLGenerator<'a> {
         );
         self.open_spans += delta;
         self.html.push_str(formatted_line.as_str());
+
+        Ok(())
     }
 
     /// Parse the line of code and update the internal HTML buffer with tagged HTML
@@ -110,7 +112,7 @@ impl<'a> ClassedHTMLGenerator<'a> {
     /// but this function can't be changed without breaking compatibility so is deprecated.
     #[deprecated(since="4.5.0", note="Please use `parse_html_for_line_which_includes_newline` instead")]
     pub fn parse_html_for_line(&mut self, line: &str) {
-        self.parse_html_for_line_which_includes_newline(line);
+        self.parse_html_for_line_which_includes_newline(line).unwrap();
         // retain newline
         self.html.push('\n');
     }
@@ -274,7 +276,7 @@ pub fn highlighted_html_for_string(
     let (mut output, bg) = start_highlighted_html_snippet(theme);
 
     for line in LinesWithEndings::from(s) {
-        let regions = highlighter.highlight_line(line, ss);
+        let regions = highlighter.highlight_line(line, ss)?;
         append_highlighted_html_for_styled_line(
             &regions[..],
             IncludeBackground::IfDifferent(bg),
@@ -302,7 +304,7 @@ pub fn highlighted_html_for_file<P: AsRef<Path>>(
     let mut line = String::new();
     while highlighter.reader.read_line(&mut line)? > 0 {
         {
-            let regions = highlighter.highlight_lines.highlight_line(&line, ss);
+            let regions = highlighter.highlight_lines.highlight_line(&line, ss)?;
             append_highlighted_html_for_styled_line(
                 &regions[..],
                 IncludeBackground::IfDifferent(bg),
@@ -433,7 +435,7 @@ fn write_css_color(s: &mut String, c: Color) {
 ///
 /// let syntax = ps.find_syntax_by_name("Ruby").unwrap();
 /// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
-/// let regions = h.highlight_line("5", &ps);
+/// let regions = h.highlight_line("5", &ps).unwrap();
 /// let html = styled_line_to_highlighted_html(&regions[..], IncludeBackground::No).unwrap();
 /// assert_eq!(html, "<span style=\"color:#d08770;\">5</span>");
 /// ```
@@ -535,7 +537,7 @@ mod tests {
         let syntax = ss.find_syntax_by_name("Markdown").unwrap();
         let mut state = ParseState::new(syntax);
         let line = "[w](t.co) *hi* **five**";
-        let ops = state.parse_line(line, &ss);
+        let ops = state.parse_line(line, &ss).expect("#[cfg(test)]");
         let mut stack = ScopeStack::new();
 
         // use util::debug_print_ops;
@@ -619,7 +621,7 @@ mod tests {
         let mut html_generator =
             ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(line);
+            html_generator.parse_html_for_line_which_includes_newline(line).expect("#[cfg(test)]");
         }
         html_generator.finalize();
     }
@@ -633,7 +635,7 @@ mod tests {
         let mut html_generator =
             ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(line);
+            html_generator.parse_html_for_line_which_includes_newline(line).expect("#[cfg(test)]");
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"source r\">x <span class=\"keyword operator arithmetic r\">+</span> y\n</span>");
@@ -650,7 +652,7 @@ mod tests {
             ClassStyle::SpacedPrefixed { prefix: "foo-" },
         );
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(line);
+            html_generator.parse_html_for_line_which_includes_newline(line).expect("#[cfg(test)]");
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"foo-source foo-r\">x <span class=\"foo-keyword foo-operator foo-arithmetic foo-r\">+</span> y\n</span>");
@@ -668,7 +670,7 @@ fn main() {
         let mut html_generator =
             ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(code) {
-            html_generator.parse_html_for_line_which_includes_newline(line);
+            html_generator.parse_html_for_line_which_includes_newline(line).expect("#[cfg(test)]");
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"source rust\"><span class=\"comment line double-slash rust\"><span class=\"punctuation definition comment rust\">//</span> Rust source\n</span><span class=\"meta function rust\"><span class=\"meta function rust\"><span class=\"storage type function rust\">fn</span> </span><span class=\"entity name function rust\">main</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters begin rust\">(</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters end rust\">)</span></span></span></span><span class=\"meta function rust\"> </span><span class=\"meta function rust\"><span class=\"meta block rust\"><span class=\"punctuation section block begin rust\">{</span>\n    <span class=\"support macro rust\">println!</span><span class=\"meta group rust\"><span class=\"punctuation section group begin rust\">(</span></span><span class=\"meta group rust\"><span class=\"string quoted double rust\"><span class=\"punctuation definition string begin rust\">&quot;</span>Hello World!<span class=\"punctuation definition string end rust\">&quot;</span></span></span><span class=\"meta group rust\"><span class=\"punctuation section group end rust\">)</span></span><span class=\"punctuation terminator rust\">;</span>\n</span><span class=\"meta block rust\"><span class=\"punctuation section block end rust\">}</span></span></span>\n</span>");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ pub enum Error {
     /// An error occurred while loading a syntax or theme
     #[error("Loading error: {0}")]
     LoadingError(#[from] LoadingError),
+    /// An error occurred while parsing
+    #[cfg(feature = "parsing")]
+    #[error("Parsing error: {0}")]
+    ParsingError(#[from] crate::parsing::ParsingError),
     /// Formatting error
     #[error("Formatting error: {0}")]
     Fmt(#[from] std::fmt::Error),

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -156,7 +156,7 @@ impl<'a> Iterator for MatchIter<'a> {
                     Pattern::Include(ref ctx_ref) => {
                         let ctx_ptr = match *ctx_ref {
                             ContextReference::Direct(ref context_id) => {
-                                self.syntax_set.get_context(context_id)
+                                self.syntax_set.get_context(context_id).unwrap()
                             }
                             _ => return self.next(), // skip this and move onto the next one
                         };
@@ -198,7 +198,7 @@ impl ContextReference {
     /// find the pointed to context, panics if ref is not linked
     pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> &'a Context {
         match *self {
-            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id),
+            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id).unwrap(),
             _ => panic!("Can only call resolve on linked references: {:?}", self),
         }
     }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -1,3 +1,4 @@
+use super::ParsingError;
 use super::syntax_definition::*;
 use super::scope::*;
 
@@ -351,9 +352,15 @@ impl SyntaxSet {
     }
 
     #[inline(always)]
-    pub(crate) fn get_context(&self, context_id: &ContextId) -> &Context {
-        let syntax = &self.syntaxes[context_id.syntax_index];
-        &syntax.contexts()[context_id.context_index]
+    pub(crate) fn get_context(&self, context_id: &ContextId) -> Result<&Context, ParsingError> {
+        let syntax = &self
+            .syntaxes
+            .get(context_id.syntax_index)
+            .ok_or_else(|| ParsingError::MissingContext(*context_id))?;
+        syntax
+            .contexts()
+            .get(context_id.context_index)
+            .ok_or_else(|| ParsingError::MissingContext(*context_id))
     }
 
     fn first_line_cache(&self) -> &FirstLineCache {
@@ -883,7 +890,7 @@ mod tests {
         // println!("{:#?}", syntax);
         assert_eq!(syntax.scope, rails_scope);
         // unreachable!();
-        let main_context = ps.get_context(&syntax.context_ids()["main"]);
+        let main_context = ps.get_context(&syntax.context_ids()["main"]).expect("#[cfg(test)]");
         let count = syntax_definition::context_iter(&ps, main_context).count();
         assert_eq!(count, 109);
     }
@@ -903,7 +910,7 @@ mod tests {
 
         let syntax = cloned_syntax_set.find_syntax_by_extension("a").unwrap();
         let mut parse_state = ParseState::new(syntax);
-        let ops = parse_state.parse_line("a go_b b", &cloned_syntax_set);
+        let ops = parse_state.parse_line("a go_b b", &cloned_syntax_set).expect("#[cfg(test)]");
         let expected = (7, ScopeStackOp::Push(Scope::new("b").unwrap()));
         assert_ops_contain(&ops, &expected);
     }
@@ -949,7 +956,7 @@ mod tests {
 
         let syntax = syntax_set.find_syntax_by_extension("c").unwrap();
         let mut parse_state = ParseState::new(syntax);
-        let ops = parse_state.parse_line("c go_a a go_b b", &syntax_set);
+        let ops = parse_state.parse_line("c go_a a go_b b", &syntax_set).expect("#[cfg(test)]");
         let expected = (14, ScopeStackOp::Push(Scope::new("b").unwrap()));
         assert_ops_contain(&ops, &expected);
     }
@@ -1000,7 +1007,7 @@ mod tests {
             .map(|line| {
                 let syntax = syntax_set.find_syntax_by_extension("a").unwrap();
                 let mut parse_state = ParseState::new(syntax);
-                parse_state.parse_line(line, &syntax_set)
+                parse_state.parse_line(line, &syntax_set).expect("#[cfg(test)]")
             })
             .collect();
 
@@ -1068,7 +1075,7 @@ mod tests {
         assert_eq!(syntax.name, "C");
 
         let mut parse_state = ParseState::new(syntax);
-        let ops = parse_state.parse_line("c go_a a", &syntax_set);
+        let ops = parse_state.parse_line("c go_a a", &syntax_set).expect("msg");
         let expected = (7, ScopeStackOp::Push(Scope::new("a2").unwrap()));
         assert_ops_contain(&ops, &expected);
     }
@@ -1083,7 +1090,7 @@ mod tests {
         let syntax = syntax_set.find_syntax_by_extension("yaml").unwrap();
 
         let mut parse_state = ParseState::new(syntax);
-        let ops = parse_state.parse_line("# test\n", &syntax_set);
+        let ops = parse_state.parse_line("# test\n", &syntax_set).expect("#[cfg(test)]");
         let expected = (0, ScopeStackOp::Push(Scope::new("comment.line.number-sign.yaml").unwrap()));
         assert_ops_contain(&ops, &expected);
     }
@@ -1160,7 +1167,7 @@ mod tests {
                 // Skip special contexts
                 continue;
             }
-            let context = syntax_set.get_context(id);
+            let context = syntax_set.get_context(id).expect("#[cfg(test)]");
             if expected.contains(&name.as_str()) {
                 assert!(context.prototype.is_some(), "Expected context {} to have prototype", name);
             } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -79,7 +79,7 @@ const LATEX_REPLACE: [(&str, &str); 3] = [
 ///
 /// let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
 ///     let escaped = as_latex_escaped(&ranges[..]);
 ///     println!("{}", escaped);
 /// }


### PR DESCRIPTION
* In `examples/` and `benches/` I simply do .unwrap()

* In tests I do `.expect("#[cfg(test)]")` to make reviewing the diff
  easy

* In deprecated methods I simply do .unwrap()

* In `uses_backrefs = uses_backrefs || proto_ids.iter().any(|id|
  syntax_set.get_context(id).unwrap().uses_backrefs);` I do an
  `.unwrap()` because `?` does not work inside of `.any()`. But that can
  be fixed later without semver breakage.

* To keep the scope of the PR manageable I do `.unwrap()` in
  `ContextReference::resolve()` and `impl<'a> Iterator for
  MatchIter<'a>` to not have to propagate an error further. That will be
  done in a follow-up PR.