### PR TITLE
TEMP CI TEST: Replace direct panics with Errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,8 @@ jobs:
           --allow clippy::unknown_clippy_lints \
           --allow clippy::unnecessary_cast \
           --allow clippy::block_in_if_condition_stmt
+        # Prevent regressions of https://github.com/trishume/syntect/issues/98
+        cargo clippy --all-features --lib -- --deny clippy::panic
     - name: Run cargo check
       run: |
         cargo check --all-features --all-targets

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -106,7 +106,7 @@ int main() {
     let css_dark_file = File::create(Path::new("theme-dark.css"))?;
     let mut css_dark_writer = BufWriter::new(&css_dark_file);
 
-    let css_dark = css_for_theme_with_class_style(dark_theme, ClassStyle::Spaced);
+    let css_dark = css_for_theme_with_class_style(dark_theme, ClassStyle::Spaced).unwrap();
     writeln!(css_dark_writer, "{}", css_dark)?;
 
     // create light color scheme css
@@ -114,7 +114,7 @@ int main() {
     let css_light_file = File::create(Path::new("theme-light.css"))?;
     let mut css_light_writer = BufWriter::new(&css_light_file);
 
-    let css_light = css_for_theme_with_class_style(light_theme, ClassStyle::Spaced);
+    let css_light = css_for_theme_with_class_style(light_theme, ClassStyle::Spaced).unwrap();
     writeln!(css_light_writer, "{}", css_light)?;
 
     Ok(())

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -85,7 +85,7 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
     let mut line_has_doc_comment = false;
     let mut line_has_code = false;
     for (s, op) in ScopeRegionIterator::new(ops, line) {
-        stack.apply(op);
+        stack.apply(op).unwrap();
         if s.is_empty() { // in this case we don't care about blank tokens
             continue;
         }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -283,7 +283,7 @@ fn test_file(
             }
             let mut col: usize = 0;
             for (s, op) in ScopeRegionIterator::new(&ops, &line) {
-                stack.apply(op);
+                stack.apply(op).unwrap();
                 if s.is_empty() {
                     // in this case we don't care about blank tokens
                     continue;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -298,7 +298,7 @@ mod tests {
         let mut stack = ScopeStack::new();
         let mut token_count = 0;
         for (s, op) in ScopeRegionIterator::new(&ops, line) {
-            stack.apply(op);
+            stack.apply(op).expect("#[cfg(test)]");
             if s.is_empty() { // in this case we don't care about blank tokens
                 continue;
             }
@@ -326,7 +326,7 @@ mod tests {
 
             let mut iterated_ops: Vec<&ScopeStackOp> = Vec::new();
             for (_, op) in ScopeRegionIterator::new(&ops, line) {
-                stack.apply(op);
+                stack.apply(op).expect("#[cfg(test)]");
                 iterated_ops.push(op);
                 println!("{:?}", op);
             }

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -181,7 +181,7 @@ impl<'a, 'b> Iterator for RangedHighlightIterator<'a, 'b> {
                         m_caches.pop();
                     }
                 }
-            });
+            }).ok()?;
         }
         self.pos = end;
         self.index += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[cfg(feature = "parsing")]
     #[error("Parsing error: {0}")]
     ParsingError(#[from] crate::parsing::ParsingError),
+    /// Scope error
+    #[error("Scope error: {0}")]
+    ScopeError(#[from] crate::parsing::ScopeError),
     /// Formatting error
     #[error("Formatting error: {0}")]
     Fmt(#[from] std::fmt::Error),

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
-use super::scope::*;
+use super::{scope::*, ParsingError};
 use super::regex::{Regex, Region};
 use regex_syntax::escape;
 use serde::{Serialize, Serializer};
@@ -192,29 +192,29 @@ pub fn context_iter<'a>(syntax_set: &'a SyntaxSet, context: &'a Context) -> Matc
 }
 
 impl Context {
-    /// Returns the match pattern at an index, panics if the thing isn't a match pattern
-    pub fn match_at(&self, index: usize) -> &MatchPattern {
+    /// Returns the match pattern at an index
+    pub fn match_at(&self, index: usize) -> Result<&MatchPattern, ParsingError> {
         match self.patterns[index] {
-            Pattern::Match(ref match_pat) => match_pat,
-            _ => panic!("bad index to match_at"),
+            Pattern::Match(ref match_pat) => Ok(match_pat),
+            _ => Err(ParsingError::BadMatchIndex(index)),
         }
     }
 }
 
 impl ContextReference {
-    /// find the pointed to context, panics if ref is not linked
-    pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> &'a Context {
+    /// find the pointed to context
+    pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> Result<&'a Context, ParsingError> {
         match *self {
-            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id).unwrap(),
-            _ => panic!("Can only call resolve on linked references: {:?}", self),
+            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id),
+            _ => Err(ParsingError::UnresolvedContextReference(self.clone())),
         }
     }
 
-    /// get the context ID this reference points to, panics if ref is not linked
-    pub fn id(&self) -> ContextId {
+    /// get the context ID this reference points to
+    pub fn id(&self) -> Result<ContextId, ParsingError> {
         match *self {
-            ContextReference::Direct(ref context_id) => *context_id,
-            _ => panic!("Can only get ContextId of linked references: {:?}", self),
+            ContextReference::Direct(ref context_id) => Ok(*context_id),
+             _ => Err(ParsingError::UnresolvedContextReference(self.clone())),
         }
     }
 }


### PR DESCRIPTION
Even though there are still `.unwrap()`s and `.expects()` left, this
change should cover the most common error code paths.

If we find a new case of an error that we want to propagate, it is
generally straightforward to deprecate the old function and add a new
function that the old function calls and `.unwrap()`.